### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/README
+++ b/README
@@ -4,5 +4,5 @@ Invenio Mobile App
 TODO
 
        - Invenio Development Team
-         <info@invenio-software.org>
-         <http://invenio-software.org/>
+         <info@inveniosoftware.org>
+         <http://inveniosoftware.org/>


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>